### PR TITLE
Don't land in the debugger on CCL.

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -12,6 +12,15 @@
   (declare (ignore condition))
   (signal 'user-abort))
 
+#+ccl
+(progn
+  (defun ccl-break-hook (cond hook)
+    "SIGINT handler on CCL."
+    (declare (ignore hook))
+    (signal cond))
+
+  (setf ccl:*break-hook* #'ccl-break-hook))
+
 (defmacro with-user-abort (&body body)
   "execute BODY, signalling user-abort if the interrupt signal is received"
   `(handler-bind ((#+sbcl sb-sys:interactive-interrupt


### PR DESCRIPTION
On CCL the test program below lands in the debugger on Ctrl-C. This PR fixes that.

```
(in-package :cl-user)

(eval-when (:compile-toplevel :load-toplevel :execute)
  (ql:quickload '(:with-user-abort) :silent t))

(defpackage test
  (:use :cl :with-user-abort))
(in-package :test)

(defun main ()
  (handler-case
      (with-user-abort 
        (print "sleeping")
        (sleep 100))
    (user-abort ()
      (print "Quitting gracefully")
      (uiop:quit 130))))

(main)
```