### PR TITLE
Fix: replace deprecated eval-when situations

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -1,6 +1,6 @@
 (in-package :with-user-abort)
 
-(eval-when (compile load eval)
+(eval-when (:compile-toplevel :load-toplevel :execute)
 
   (defun get-implementation-condition ()
     (quote


### PR DESCRIPTION
Use :compile-toplevel, :load-toplevel, and :execute instead of deprecated compile, load, and eval.

See here https://www.lispworks.com/documentation/lw50/CLHS/Body/s_eval_w.htm :
> The use of [eval](https://www.lispworks.com/documentation/lw50/CLHS/Body/f_eval.htm#eval), [compile](https://www.lispworks.com/documentation/lw50/CLHS/Body/f_cmp.htm#compile), and [load](https://www.lispworks.com/documentation/lw50/CLHS/Body/f_load.htm#load) is deprecated.